### PR TITLE
Revert "INTYGFV-11096: textändring ts-bas (#17)"

### DIFF
--- a/src/main/resources/texts/texterTS_TSTRK_1007_v6.7.xml
+++ b/src/main/resources/texts/texterTS_TSTRK_1007_v6.7.xml
@@ -242,7 +242,7 @@ Avser svenskt EU-pass, annat EU-pass utfärdade från och med den 1 september 20
 
   <text id="FRG_33.RBK">Patienten uppfyller kraven enligt Transportstyrelsens föreskrifter och allmänna råd om medicinska krav för innehav av körkort m.m. (TSFS 2010:125, senast ändrade genom TSFS 2013:2) för:</text>
 	<text id="DFR_33.1.RBK">Någon av följande behörigheter:</text>
-  <text id="DFR_33.2.RBK">Ej angivet</text>
+  <text id="DFR_33.2.RBK">Kan inte ta ställning</text>
 	<text id="FRG_34.RBK">Patienten bör före ärendets avgörande undersökas av läkare med specialistkompetens i:</text>
 
 </texter>

--- a/src/main/resources/texts/texterTS_TSTRK_1007_v6.8.xml
+++ b/src/main/resources/texts/texterTS_TSTRK_1007_v6.8.xml
@@ -255,7 +255,7 @@ Avser svenskt EU-pass, annat EU-pass utfärdade från och med den 1 september 20
 	<text id="KAT_101.RBK">Bedömning</text>
 
   <text id="FRG_33.RBK">Ange för vilka behörigheter som patienten uppfyller kraven enligt Transportstyrelsens föreskrifter och allmänna råd om medicinska krav för innehav av körkort m.m.(TSFS 2010:125)</text>
-  <text id="DFR_33.2.RBK">Ej angivet</text>
+  <text id="DFR_33.2.RBK">Kan inte ta ställning</text>
 	<text id="FRG_34.RBK">Patienten bör före ärendets avgörande undersökas av läkare med specialistkompetens i</text>
 
 	<!--


### PR DESCRIPTION
This reverts commit 5f932d91217b0877c15c8ec33f1678f598384e24.

Ändringen förstör normalflödet. Dvs anger man "Kan inte ta ställning" så står det "ej angivet" i det signerade intyget.