### PR TITLE
INTYGFV-11394: Added possibility to prefill doi from db from webcert search view

### DIFF
--- a/src/main/resources/webcert/authorities.yaml
+++ b/src/main/resources/webcert/authorities.yaml
@@ -632,6 +632,11 @@ roles:
               - *ki050 # luse
               - *ki060 # luae_na
               - *ki070 # luae_fs
+      - <<: *p190 # KOPIERA_FRAN_KANDIDAT
+        requestOrigins:
+          - <<: *ro010 # NORMAL
+            intygstyper:
+              - *ki090 # doi
       - <<: *p200 # KOPIERA_LAST_UTKAST
       - <<: *p210 # MARKERA_KOMPLETTERING_SOM_HANTERAD
         requestOrigins:
@@ -1026,6 +1031,10 @@ roles:
           - <<: *ro020 # DJUPINTEGRATION
             intygstyper:
               - *ki120 # ag7804
+              - *ki090 # doi
+          - <<: *ro010 # NORMAL
+            intygstyper:
+              - *ki090 # doi
       - <<: *p200 # KOPIERA_LAST_UTKAST
       - <<: *p210 # MARKERA_KOMPLETTERING_SOM_HANTERAD
         requestOrigins:

--- a/src/main/resources/webcert/authorities.yaml
+++ b/src/main/resources/webcert/authorities.yaml
@@ -347,6 +347,7 @@ privileges:
     desc: Kopiera data från signerat intyg (kandidat) till utkast som skapats upp via djupintegration
     intygstyper:
       - *ki120 # ag7804
+      - *ki090 # doi                          ADDED BY MH FOR TEST
     requestOrigins:
       - *ro020 # DJUPINTEGRATION
   - &p200
@@ -527,6 +528,10 @@ roles:
           - <<: *ro020 # DJUPINTEGRATION
             intygstyper:
               - *ki120 # ag7804
+              - *ki090 # doi
+          - <<: *ro010 # NORMAL
+            intygstyper:
+              - *ki090 # doi
       - <<: *p200 # KOPIERA_LAST_UTKAST
       - <<: *p210 # MARKERA_KOMPLETTERING_SOM_HANTERAD
         requestOrigins:

--- a/src/main/resources/webcert/authorities.yaml
+++ b/src/main/resources/webcert/authorities.yaml
@@ -344,10 +344,10 @@ privileges:
     requestOrigins: # Implicit alla
   - &p190
     name: *kp190
-    desc: Kopiera data från signerat intyg (kandidat) till utkast som skapats upp via djupintegration
+    desc: Kopiera data från signerat intyg (kandidat) till utkast
     intygstyper:
       - *ki120 # ag7804
-      - *ki090 # doi                          ADDED BY MH FOR TEST
+      - *ki090 # doi
     requestOrigins:
       - *ro020 # DJUPINTEGRATION
   - &p200


### PR DESCRIPTION
This jira adds the possibility to prefill a doi draft with data from an existing db certicate. Prefill should be available in NORMAL and DJUPINTEGRERAD via modal if the user and the db certificate are on the same care unit or a sub unit of the same care unit. In cases where the user and the db certificate are on different care units but within the same care giver two consecutive modals sholuld offer an option to view info about at which unit the candidate db certificate was issued. The db candidate to use for prefill is selected based on prerequisites specified in the jira text. The jira also included hiding, in DJUPINTEGRERAD mode, of the button allowing prefill of doi from db from within the db cerificate view. Code has also been added in webcert and common.